### PR TITLE
fix: foundry.toml env vars

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -21,6 +21,8 @@ remappings = [
 
 [rpc_endpoints]
 FORKING_RPC_URL = "${FORKING_RPC_URL}"
+ETH_RPC_URL = "${ETH_RPC_URL}"
+POLYGON_RPC_URL = "${POLYGON_RPC_URL}"
 
 [profile.ci]
 src = 'src'


### PR DESCRIPTION
the environment variables weren't being read from the .env file so this fixes that